### PR TITLE
create calc_uslope subroutines for each slope_type

### DIFF
--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -9,7 +9,7 @@ contains
    !!! USLOPE SUBROUTINE FOR EACH SLOPE TYPE !!!
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-   !DIR$ ATTRIBUTES FORCEINLINE :: calc_uslope_minmod_average
+   !DIR$ FORCEINLINE :: calc_uslope_minmod_average
    pure subroutine calc_uslope_minmod_average(q,dq,i,j,k,ngrid,slope_type_real)
       use hydro_parameters
       implicit none
@@ -24,8 +24,6 @@ contains
       integer::l
       real(dp)::dlft, drgt, qcen
 
-      !DIR$ IVDEP
-      !DIR$ SIMD
       do l = 1, ngrid
          qcen = q(l,i,j,k)
 
@@ -71,8 +69,6 @@ contains
       integer::l
       real(dp)::dlft, drgt, qcen
 
-      !DIR$ IVDEP
-      !DIR$ SIMD
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k)
@@ -112,8 +108,6 @@ contains
       real(dp)::dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr
       real(dp)::vmin,vmax,dfx,dfy,dff
 
-      !DIR$ IVDEP
-      !DIR$ SIMD
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k)
@@ -164,8 +158,6 @@ contains
       real(dp)::dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr
       real(dp)::vmin,vmax,dfx,dfy,dfz,dff
 
-      !DIR$ IVDEP
-      !DIR$ SIMD
       do l = 1, ngrid
          qcen = q(l,i,j,k)
 
@@ -239,8 +231,7 @@ contains
       !--------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen,dcen,dsgn,dlim
-      !DIR$ IVDEP
-      !DIR$ SIMD
+
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k,n)
@@ -254,6 +245,7 @@ contains
          if((dlft*drgt)<=zero)dlim=zero
          dq(l,1) = dsgn*dlim !min(dlim,abs(dcen))
       end do
+
    end subroutine calc_uslope_superbee
    !#######################################################
    pure subroutine calc_uslope_ultrabee(q,dq,i,j,k,n,ngrid,dtdx)
@@ -269,8 +261,7 @@ contains
       !--------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen,dcen,dsgn,dlim
-      !DIR$ IVDEP
-      !DIR$ SIMD
+
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k,n)
@@ -288,6 +279,7 @@ contains
          if((dlft*drgt)<=zero)dlim=zero
          dq(l,1) = dsgn*dlim !min(dlim,abs(dcen))
       end do
+   
    end subroutine calc_uslope_ultrabee
    !#######################################################
    pure subroutine calc_uslope_unstable(q,dq,i,j,k,ngrid)
@@ -302,8 +294,7 @@ contains
       !--------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen
-      !DIR$ IVDEP
-      !DIR$ SIMD
+
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k)
@@ -312,6 +303,7 @@ contains
          drgt = q(l,i+1,j,k) - qcen
          dq(l,1) = 0.5d0*(dlft+drgt)
       end do
+
    end subroutine calc_uslope_unstable
 #endif
    !#######################################################
@@ -328,8 +320,6 @@ contains
       integer::l
       real(dp)::dlft, drgt, qcen
 
-      !DIR$ IVDEP
-      !DIR$ SIMD
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k)
@@ -367,8 +357,6 @@ contains
       integer::l
       real(dp)::dlft, drgt, qcen
 
-      !DIR$ IVDEP
-      !DIR$ SIMD
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
          qcen = q(l,i,j,k)

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -9,7 +9,7 @@ contains
    !!! USLOPE SUBROUTINE FOR EACH SLOPE TYPE !!!
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-   subroutine calc_uslope_minmod_average(q,dq,i,j,k,ngrid,slope_type_real)
+   pure subroutine calc_uslope_minmod_average(q,dq,i,j,k,ngrid,slope_type_real)
       use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
@@ -17,9 +17,9 @@ contains
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k
       real(dp),intent(in)::slope_type_real
-      !-----------------------------------------
-      ! 
-      !-----------------------------------------
+      !-----------------------------------------------------
+      ! Calculate minmod or average slope for each direction
+      !-----------------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen
 
@@ -56,6 +56,217 @@ contains
 
    end subroutine calc_uslope_minmod_average
    !#######################################################
+#if NDIM==3
+   subroutine calc_uslope_moncen(q,dq,i,j,k,ngrid)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      !--------------------------------------------------
+      ! Calculate moncen slope for each direction
+      !--------------------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen
+
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k)
+
+         ! slopes in first coordinate direction
+         dlft = qcen - q(l,i-1,j,k)
+         drgt = q(l,i+1,j,k) - qcen
+         dq(l,1) = slope_moncen(dlft,drgt)
+
+         ! slopes in second coordinate direction
+         dlft = qcen - q(l,i,j-1,k)
+         drgt = q(l,i,j+1,k) - qcen
+         dq(l,2) = slope_moncen(dlft,drgt)
+
+         ! slopes in third coordinate direction
+         dlft = qcen - q(l,i,j,k-1)
+         drgt = q(l,i,j,k+1) - qcen
+         dq(l,3) = slope_moncen(dlft,drgt)
+      end do
+
+   end subroutine calc_uslope_moncen
+#endif
+   !#######################################################
+#if NDIM==2
+   subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      !--------------------------------------------------
+      ! Calculate positivity preserving 2D unsplit slope slope for each direction
+      !--------------------------------------------------
+      integer::l
+      real(dp)::dlft,drgt,qcen,dlim
+      real(dp)::dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr
+      real(dp)::vmin,vmax,dfx,dfy,dff
+
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k)
+
+         dfll = q(l,i-1,j-1,k) - qcen
+         dflm = q(l,i-1,j  ,k) - qcen
+         dflr = q(l,i-1,j+1,k) - qcen
+         dfml = q(l,i  ,j-1,k) - qcen
+         dfmm = 0
+         dfmr = q(l,i  ,j+1,k) - qcen
+         dfrl = q(l,i+1,j-1,k) - qcen
+         dfrm = q(l,i+1,j  ,k) - qcen
+         dfrr = q(l,i+1,j+1,k) - qcen
+
+         vmin = min(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
+         vmax = max(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
+
+         dfx  = half*(q(l,i+1,j,k)-q(l,i-1,j,k))
+         dfy  = half*(q(l,i,j+1,k)-q(l,i,j-1,k))
+         dff  = half*(abs(dfx)+abs(dfy))
+
+         if(dff>zero)then
+            dlim = min(one,min(abs(vmin),abs(vmax))/dff)
+         else
+            dlim = one
+         endif
+
+         dq(l,1) = dlim*dfx
+         dq(l,2) = dlim*dfy
+      end do
+
+   end subroutine calc_uslope_positivity_preserving
+#elif NDIM==3
+   subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      !--------------------------------------------------------------------------
+      ! Calculate positivity preserving 3D unsplit slope slope for each direction
+      !--------------------------------------------------------------------------
+      integer::l
+      real(dp)::dlft,drgt,qcen,dlim
+      real(dp)::dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl
+      real(dp)::dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm
+      real(dp)::dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr
+      real(dp)::vmin,vmax,dfx,dfy,dfz,dff
+
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         qcen = q(l,i,j,k)
+
+         dflll = q(l,i-1,j-1,k-1) - qcen
+         dflml = q(l,i-1,j  ,k-1) - qcen
+         dflrl = q(l,i-1,j+1,k-1) - qcen
+         dfmll = q(l,i  ,j-1,k-1) - qcen
+         dfmml = q(l,i  ,j  ,k-1) - qcen
+         dfmrl = q(l,i  ,j+1,k-1) - qcen
+         dfrll = q(l,i+1,j-1,k-1) - qcen
+         dfrml = q(l,i+1,j  ,k-1) - qcen
+         dfrrl = q(l,i+1,j+1,k-1) - qcen
+
+         dfllm = q(l,i-1,j-1,k  ) - qcen
+         dflmm = q(l,i-1,j  ,k  ) - qcen
+         dflrm = q(l,i-1,j+1,k  ) - qcen
+         dfmlm = q(l,i  ,j-1,k  ) - qcen
+         dfmmm = 0
+         dfmrm = q(l,i  ,j+1,k  ) - qcen
+         dfrlm = q(l,i+1,j-1,k  ) - qcen
+         dfrmm = q(l,i+1,j  ,k  ) - qcen
+         dfrrm = q(l,i+1,j+1,k  ) - qcen
+
+         dfllr = q(l,i-1,j-1,k+1) - qcen
+         dflmr = q(l,i-1,j  ,k+1) - qcen
+         dflrr = q(l,i-1,j+1,k+1) - qcen
+         dfmlr = q(l,i  ,j-1,k+1) - qcen
+         dfmmr = q(l,i  ,j  ,k+1) - qcen
+         dfmrr = q(l,i  ,j+1,k+1) - qcen
+         dfrlr = q(l,i+1,j-1,k+1) - qcen
+         dfrmr = q(l,i+1,j  ,k+1) - qcen
+         dfrrr = q(l,i+1,j+1,k+1) - qcen
+
+         vmin = min(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
+               &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
+               &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
+         vmax = max(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
+               &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
+               &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
+
+         dfx  = half*(q(l,i+1,j,k) - q(l,i-1,j,k))
+         dfy  = half*(q(l,i,j+1,k) - q(l,i,j-1,k))
+         dfz  = half*(q(l,i,j,k+1) - q(l,i,j,k-1))
+         dff  = half*(abs(dfx)+abs(dfy)+abs(dfz))
+
+         if(dff>zero)then
+            dlim = min(one,min(abs(vmin),abs(vmax))/dff)
+         else
+            dlim = one
+         endif
+
+         dq(l,1) = dlim*dfx
+         dq(l,2) = dlim*dfy
+         dq(l,3) = dlim*dfz
+      end do
+
+   end subroutine calc_uslope_positivity_preserving
+#endif
+   !#######################################################
+#if NDIM==1
+
+#endif
+   !#######################################################
+   subroutine calc_uslope_vanLeer(q,dq,i,j,k,ngrid)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      !--------------------------------------------------
+      ! Calculate van Leer slope for each direction
+      !--------------------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen
+
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k)
+
+         ! slopes in first coordinate direction
+         dlft = qcen - q(l,i-1,j,k)
+         drgt = q(l,i+1,j,k) - qcen
+         dq(l,1) = slope_vanLeer(dlft,drgt)
+#if NDIM>1
+         ! slopes in second coordinate direction
+         dlft = qcen - q(l,i,j-1,k)
+         drgt = q(l,i,j+1,k) - qcen
+         dq(l,2) = slope_vanLeer(dlft,drgt)
+#endif
+#if NDIM>2
+         ! slopes in third coordinate direction
+         dlft = qcen - q(l,i,j,k-1)
+         drgt = q(l,i,j,k+1) - qcen
+         dq(l,3) = slope_vanLeer(dlft,drgt)
+#endif
+      end do
+
+   end subroutine calc_uslope_vanLeer
+   !#######################################################
    subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,ngrid)
       use hydro_parameters
       implicit none
@@ -63,9 +274,9 @@ contains
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k
-      !-----------------------------------------
-      ! Apply van Leer (bis) slope
-      !-----------------------------------------
+      !--------------------------------------------------
+      ! Calculate van Leer (bis) slope for each direction
+      !--------------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen
 

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -10,7 +10,6 @@ contains
    !!! USLOPE SUBROUTINE FOR EACH SLOPE TYPE !!!
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-   !DIR$ FORCEINLINE :: calc_uslope_minmod_average
    pure subroutine calc_uslope_minmod_average(q,dq,i,j,k,n,ngrid,slope_type_real)
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -57,16 +57,16 @@ contains
    end subroutine calc_uslope_minmod_average
    !#######################################################
 #if NDIM==3
-   subroutine calc_uslope_moncen(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_moncen(q,dq,i,j,k,ngrid)
       use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k
-      !--------------------------------------------------
+      !------------------------------------------
       ! Calculate moncen slope for each direction
-      !--------------------------------------------------
+      !------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen
 
@@ -96,16 +96,16 @@ contains
 #endif
    !#######################################################
 #if NDIM==2
-   subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
       use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k
-      !--------------------------------------------------
+      !--------------------------------------------------------------------------
       ! Calculate positivity preserving 2D unsplit slope slope for each direction
-      !--------------------------------------------------
+      !--------------------------------------------------------------------------
       integer::l
       real(dp)::dlft,drgt,qcen,dlim
       real(dp)::dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr
@@ -146,7 +146,7 @@ contains
 
    end subroutine calc_uslope_positivity_preserving
 #elif NDIM==3
-   subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
       use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
@@ -225,19 +225,105 @@ contains
 #endif
    !#######################################################
 #if NDIM==1
-
-#endif
+   pure subroutine calc_uslope_superbee(q,dq,i,j,k,n,ngrid,dtdx)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k, n
+      real(dp),intent(in)::dtdx
+      !--------------------------------------------
+      ! Calculate superbee slope for each direction
+      !--------------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen,dcen,dsgn,dlim
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k,n)
+         dcen = q(l,i,j,k,2)*dtdx
+         ! slopes in first coordinate direction
+         dlft = two/(one+dcen)*(qcen - q(l,i-1,j,k,n))
+         drgt = two/(one-dcen)*(q(l,i+1,j,k,n) - qcen)
+         !dcen = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
+         dsgn = sign(one, dlft)
+         dlim = min(abs(dlft),abs(drgt))
+         if((dlft*drgt)<=zero)dlim=zero
+         dq(l,1) = dsgn*dlim !min(dlim,abs(dcen))
+      end do
+   end subroutine calc_uslope_superbee
    !#######################################################
-   subroutine calc_uslope_vanLeer(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_ultrabee(q,dq,i,j,k,n,ngrid,dtdx)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k, n
+      real(dp),intent(in)::dtdx
+      !--------------------------------------------
+      ! Calculate ultrabee slope for each direction
+      !--------------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen,dcen,dsgn,dlim
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k,n)
+         dcen = q(l,i,j,k,2)*dtdx
+         if(dcen>=0)then
+            dlft = two/(zero+dcen+1d-10)*(qcen - q(l,i-1,j,k,n))
+            drgt = two/(one -dcen      )*(q(l,i+1,j,k,n) - qcen)
+         else
+            dlft = two/(one +dcen      )*(qcen - q(l,i-1,j,k,n))
+            drgt = two/(zero-dcen+1d-10)*(q(l,i+1,j,k,n) - qcen)
+         endif
+         dsgn = sign(one, dlft)
+         dlim = min(abs(dlft),abs(drgt))
+         !dcen = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
+         if((dlft*drgt)<=zero)dlim=zero
+         dq(l,1) = dsgn*dlim !min(dlim,abs(dcen))
+      end do
+   end subroutine calc_uslope_ultrabee
+   !#######################################################
+   pure subroutine calc_uslope_unstable(q,dq,i,j,k,ngrid)
       use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k
-      !--------------------------------------------------
+      !--------------------------------------------
+      ! Calculate unstable slope for each direction
+      !--------------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k)
+         ! slopes in first coordinate direction
+         dlft = qcen - q(l,i-1,j,k)
+         drgt = q(l,i+1,j,k) - qcen
+         dq(l,1) = 0.5d0*(dlft+drgt)
+      end do
+   end subroutine calc_uslope_unstable
+#endif
+   !#######################################################
+   pure subroutine calc_uslope_vanLeer(q,dq,i,j,k,ngrid)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      !--------------------------------------------
       ! Calculate van Leer slope for each direction
-      !--------------------------------------------------
+      !--------------------------------------------
       integer::l
       real(dp)::dlft, drgt, qcen
 
@@ -267,7 +353,7 @@ contains
 
    end subroutine calc_uslope_vanLeer
    !#######################################################
-   subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,ngrid)
       use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -1,9 +1,103 @@
 module slope_types
-   use amr_parameters, only:dp
+   use amr_parameters, only:dp,nvector,ndim
    use const
    implicit none
 
 contains
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !!! USLOPE SUBROUTINE FOR EACH SLOPE TYPE !!!
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine calc_uslope_minmod_average(q,dq,i,j,k,ngrid,slope_type_real)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      real(dp),intent(in)::slope_type_real
+      !-----------------------------------------
+      ! 
+      !-----------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen
+
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         qcen = q(l,i,j,k)
+
+         ! slopes in first coordinate direction
+         dlft = qcen - q(l,i-1,j,k)
+         drgt = q(l,i+1,j,k) - qcen
+#if NDIM==1 || NDIM==2
+         dq(l,1) = slope_minmod_or_average(dlft,drgt,slope_type_real)
+#else
+         dq(l,1) = slope_minmod(dlft,drgt)
+#endif
+#if NDIM>1
+         ! slopes in second coordinate direction
+         dlft = qcen - q(l,i,j-1,k)
+         drgt = q(l,i,j+1,k) - qcen
+#if NDIM==2
+         dq(l,2) = slope_minmod_or_average(dlft,drgt,slope_type_real)
+#else
+         dq(l,2) = slope_minmod(dlft,drgt)
+#endif
+#endif
+#if NDIM>2
+         ! slopes in third coordinate direction
+         dlft = qcen - q(l,i,j,k-1)
+         drgt = q(l,i,j,k+1) - qcen
+         dq(l,3) = slope_minmod(dlft,drgt)
+#endif
+      end do
+
+   end subroutine calc_uslope_minmod_average
+   !#######################################################
+   subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,ngrid)
+      use hydro_parameters
+      implicit none
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
+      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      integer,intent(in)::ngrid
+      integer,intent(in)::i, j, k
+      !-----------------------------------------
+      ! Apply van Leer (bis) slope
+      !-----------------------------------------
+      integer::l
+      real(dp)::dlft, drgt, qcen
+
+      !DIR$ IVDEP
+      !DIR$ SIMD
+      do l = 1, ngrid
+         ! Gather values at center cell and its neighbors
+         qcen = q(l,i,j,k)
+
+         ! slopes in first coordinate direction
+         dlft = qcen - q(l,i-1,j,k)
+         drgt = q(l,i+1,j,k) - qcen
+         dq(l,1) = slope_vanLeer_bis(dlft,drgt)
+#if NDIM>1
+         ! slopes in second coordinate direction
+         dlft = qcen - q(l,i,j-1,k)
+         drgt = q(l,i,j+1,k) - qcen
+         dq(l,2) = slope_vanLeer_bis(dlft,drgt)
+#endif
+#if NDIM>2
+         ! slopes in third coordinate direction
+         dlft = qcen - q(l,i,j,k-1)
+         drgt = q(l,i,j,k+1) - qcen
+         dq(l,3) = slope_vanLeer_bis(dlft,drgt)
+#endif
+      end do
+
+   end subroutine calc_uslope_vanLeer_bis
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !!! SLOPE TYPE EQUATIONS !!!
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !#######################################################
    !DIR$ ATTRIBUTES FORCEINLINE :: slope_minmod

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -29,7 +29,7 @@ contains
          ! slopes in first coordinate direction
          dlft = qcen - q(l,i-1,j,k,n)
          drgt = q(l,i+1,j,k,n) - qcen
-#if NDIM==1 || NDIM==2
+#if NDIM==1 || NDIM==2 || defined(SOLVERmhd)
          dq(l,i,j,k,n,1) = slope_minmod_or_average(dlft,drgt,slope_type_real)
 #else
          dq(l,i,j,k,n,1) = slope_minmod(dlft,drgt)
@@ -38,7 +38,7 @@ contains
          ! slopes in second coordinate direction
          dlft = qcen - q(l,i,j-1,k,n)
          drgt = q(l,i,j+1,k,n) - qcen
-#if NDIM==2
+#if NDIM==2 || defined(SOLVERmhd)
          dq(l,i,j,k,n,2) = slope_minmod_or_average(dlft,drgt,slope_type_real)
 #else
          dq(l,i,j,k,n,2) = slope_minmod(dlft,drgt)
@@ -48,13 +48,17 @@ contains
          ! slopes in third coordinate direction
          dlft = qcen - q(l,i,j,k-1,n)
          drgt = q(l,i,j,k+1,n) - qcen
+#if defined(SOLVERmhd)
+         dq(l,i,j,k,n,3) = slope_minmod_or_average(dlft,drgt,slope_type_real)
+#else
          dq(l,i,j,k,n,3) = slope_minmod(dlft,drgt)
+#endif
 #endif
       end do
 
    end subroutine calc_uslope_minmod_average
    !#######################################################
-#if NDIM==3
+#if NDIM==3 || defined(SOLVERhydro)
    pure subroutine calc_uslope_moncen(q,dq,i,j,k,n,ngrid)
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -55,12 +55,12 @@ contains
    end subroutine calc_uslope_minmod_average
    !#######################################################
 #if NDIM==3
-   pure subroutine calc_uslope_moncen(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_moncen(q,dq,i,j,k,n,ngrid)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       !------------------------------------------
       ! Calculate moncen slope for each direction
       !------------------------------------------
@@ -69,34 +69,34 @@ contains
 
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
 
          ! slopes in first coordinate direction
-         dlft = qcen - q(l,i-1,j,k)
-         drgt = q(l,i+1,j,k) - qcen
-         dq(l,1) = slope_moncen(dlft,drgt)
+         dlft = qcen - q(l,i-1,j,k,n)
+         drgt = q(l,i+1,j,k,n) - qcen
+         dq(l,i,j,k,n,1) = slope_moncen(dlft,drgt)
 
          ! slopes in second coordinate direction
-         dlft = qcen - q(l,i,j-1,k)
-         drgt = q(l,i,j+1,k) - qcen
-         dq(l,2) = slope_moncen(dlft,drgt)
+         dlft = qcen - q(l,i,j-1,k,n)
+         drgt = q(l,i,j+1,k,n) - qcen
+         dq(l,i,j,k,n,2) = slope_moncen(dlft,drgt)
 
          ! slopes in third coordinate direction
-         dlft = qcen - q(l,i,j,k-1)
-         drgt = q(l,i,j,k+1) - qcen
-         dq(l,3) = slope_moncen(dlft,drgt)
+         dlft = qcen - q(l,i,j,k-1,n)
+         drgt = q(l,i,j,k+1,n) - qcen
+         dq(l,i,j,k,n,3) = slope_moncen(dlft,drgt)
       end do
 
    end subroutine calc_uslope_moncen
 #endif
    !#######################################################
 #if NDIM==2
-   pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,n,ngrid)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       !--------------------------------------------------------------------------
       ! Calculate positivity preserving 2D unsplit slope slope for each direction
       !--------------------------------------------------------------------------
@@ -107,23 +107,23 @@ contains
 
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
 
-         dfll = q(l,i-1,j-1,k) - qcen
-         dflm = q(l,i-1,j  ,k) - qcen
-         dflr = q(l,i-1,j+1,k) - qcen
-         dfml = q(l,i  ,j-1,k) - qcen
+         dfll = q(l,i-1,j-1,k,n) - qcen
+         dflm = q(l,i-1,j  ,k,n) - qcen
+         dflr = q(l,i-1,j+1,k,n) - qcen
+         dfml = q(l,i  ,j-1,k,n) - qcen
          dfmm = 0
-         dfmr = q(l,i  ,j+1,k) - qcen
-         dfrl = q(l,i+1,j-1,k) - qcen
-         dfrm = q(l,i+1,j  ,k) - qcen
-         dfrr = q(l,i+1,j+1,k) - qcen
+         dfmr = q(l,i  ,j+1,k,n) - qcen
+         dfrl = q(l,i+1,j-1,k,n) - qcen
+         dfrm = q(l,i+1,j  ,k,n) - qcen
+         dfrr = q(l,i+1,j+1,k,n) - qcen
 
          vmin = min(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
          vmax = max(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
 
-         dfx  = half*(q(l,i+1,j,k)-q(l,i-1,j,k))
-         dfy  = half*(q(l,i,j+1,k)-q(l,i,j-1,k))
+         dfx  = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
+         dfy  = half*(q(l,i,j+1,k,n)-q(l,i,j-1,k,n))
          dff  = half*(abs(dfx)+abs(dfy))
 
          if(dff>zero)then
@@ -132,18 +132,18 @@ contains
             dlim = one
          endif
 
-         dq(l,1) = dlim*dfx
-         dq(l,2) = dlim*dfy
+         dq(l,i,j,k,n,1) = dlim*dfx
+         dq(l,i,j,k,n,2) = dlim*dfy
       end do
 
    end subroutine calc_uslope_positivity_preserving
 #elif NDIM==3
-   pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,n,ngrid)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       !--------------------------------------------------------------------------
       ! Calculate positivity preserving 3D unsplit slope slope for each direction
       !--------------------------------------------------------------------------
@@ -155,37 +155,37 @@ contains
       real(dp)::vmin,vmax,dfx,dfy,dfz,dff
 
       do l = 1, ngrid
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
 
-         dflll = q(l,i-1,j-1,k-1) - qcen
-         dflml = q(l,i-1,j  ,k-1) - qcen
-         dflrl = q(l,i-1,j+1,k-1) - qcen
-         dfmll = q(l,i  ,j-1,k-1) - qcen
-         dfmml = q(l,i  ,j  ,k-1) - qcen
-         dfmrl = q(l,i  ,j+1,k-1) - qcen
-         dfrll = q(l,i+1,j-1,k-1) - qcen
-         dfrml = q(l,i+1,j  ,k-1) - qcen
-         dfrrl = q(l,i+1,j+1,k-1) - qcen
+         dflll = q(l,i-1,j-1,k-1,n) - qcen
+         dflml = q(l,i-1,j  ,k-1,n) - qcen
+         dflrl = q(l,i-1,j+1,k-1,n) - qcen
+         dfmll = q(l,i  ,j-1,k-1,n) - qcen
+         dfmml = q(l,i  ,j  ,k-1,n) - qcen
+         dfmrl = q(l,i  ,j+1,k-1,n) - qcen
+         dfrll = q(l,i+1,j-1,k-1,n) - qcen
+         dfrml = q(l,i+1,j  ,k-1,n) - qcen
+         dfrrl = q(l,i+1,j+1,k-1,n) - qcen
 
-         dfllm = q(l,i-1,j-1,k  ) - qcen
-         dflmm = q(l,i-1,j  ,k  ) - qcen
-         dflrm = q(l,i-1,j+1,k  ) - qcen
-         dfmlm = q(l,i  ,j-1,k  ) - qcen
+         dfllm = q(l,i-1,j-1,k  ,n) - qcen
+         dflmm = q(l,i-1,j  ,k  ,n) - qcen
+         dflrm = q(l,i-1,j+1,k  ,n) - qcen
+         dfmlm = q(l,i  ,j-1,k  ,n) - qcen
          dfmmm = 0
-         dfmrm = q(l,i  ,j+1,k  ) - qcen
-         dfrlm = q(l,i+1,j-1,k  ) - qcen
-         dfrmm = q(l,i+1,j  ,k  ) - qcen
-         dfrrm = q(l,i+1,j+1,k  ) - qcen
+         dfmrm = q(l,i  ,j+1,k  ,n) - qcen
+         dfrlm = q(l,i+1,j-1,k  ,n) - qcen
+         dfrmm = q(l,i+1,j  ,k  ,n) - qcen
+         dfrrm = q(l,i+1,j+1,k  ,n) - qcen
 
-         dfllr = q(l,i-1,j-1,k+1) - qcen
-         dflmr = q(l,i-1,j  ,k+1) - qcen
-         dflrr = q(l,i-1,j+1,k+1) - qcen
-         dfmlr = q(l,i  ,j-1,k+1) - qcen
-         dfmmr = q(l,i  ,j  ,k+1) - qcen
-         dfmrr = q(l,i  ,j+1,k+1) - qcen
-         dfrlr = q(l,i+1,j-1,k+1) - qcen
-         dfrmr = q(l,i+1,j  ,k+1) - qcen
-         dfrrr = q(l,i+1,j+1,k+1) - qcen
+         dfllr = q(l,i-1,j-1,k+1,n) - qcen
+         dflmr = q(l,i-1,j  ,k+1,n) - qcen
+         dflrr = q(l,i-1,j+1,k+1,n) - qcen
+         dfmlr = q(l,i  ,j-1,k+1,n) - qcen
+         dfmmr = q(l,i  ,j  ,k+1,n) - qcen
+         dfmrr = q(l,i  ,j+1,k+1,n) - qcen
+         dfrlr = q(l,i+1,j-1,k+1,n) - qcen
+         dfrmr = q(l,i+1,j  ,k+1,n) - qcen
+         dfrrr = q(l,i+1,j+1,k+1,n) - qcen
 
          vmin = min(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
                &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
@@ -194,9 +194,9 @@ contains
                &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
                &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
 
-         dfx  = half*(q(l,i+1,j,k) - q(l,i-1,j,k))
-         dfy  = half*(q(l,i,j+1,k) - q(l,i,j-1,k))
-         dfz  = half*(q(l,i,j,k+1) - q(l,i,j,k-1))
+         dfx  = half*(q(l,i+1,j,k,n) - q(l,i-1,j,k,n))
+         dfy  = half*(q(l,i,j+1,k,n) - q(l,i,j-1,k,n))
+         dfz  = half*(q(l,i,j,k+1,n) - q(l,i,j,k-1,n))
          dff  = half*(abs(dfx)+abs(dfy)+abs(dfz))
 
          if(dff>zero)then
@@ -205,9 +205,9 @@ contains
             dlim = one
          endif
 
-         dq(l,1) = dlim*dfx
-         dq(l,2) = dlim*dfy
-         dq(l,3) = dlim*dfz
+         dq(l,i,j,k,n,1) = dlim*dfx
+         dq(l,i,j,k,n,2) = dlim*dfy
+         dq(l,i,j,k,n,3) = dlim*dfz
       end do
 
    end subroutine calc_uslope_positivity_preserving
@@ -217,7 +217,7 @@ contains
    pure subroutine calc_uslope_superbee(q,dq,i,j,k,n,ngrid,dtdx)
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k, n
       real(dp),intent(in)::dtdx
@@ -238,7 +238,7 @@ contains
          dsgn = sign(one, dlft)
          dlim = min(abs(dlft),abs(drgt))
          if((dlft*drgt)<=zero)dlim=zero
-         dq(l,1) = dsgn*dlim !min(dlim,abs(dcen))
+         dq(l,i,j,k,n,1) = dsgn*dlim !min(dlim,abs(dcen))
       end do
 
    end subroutine calc_uslope_superbee
@@ -246,7 +246,7 @@ contains
    pure subroutine calc_uslope_ultrabee(q,dq,i,j,k,n,ngrid,dtdx)
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
       integer,intent(in)::i, j, k, n
       real(dp),intent(in)::dtdx
@@ -271,17 +271,17 @@ contains
          dlim = min(abs(dlft),abs(drgt))
          !dcen = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
          if((dlft*drgt)<=zero)dlim=zero
-         dq(l,1) = dsgn*dlim !min(dlim,abs(dcen))
+         dq(l,i,j,k,n,1) = dsgn*dlim !min(dlim,abs(dcen))
       end do
    
    end subroutine calc_uslope_ultrabee
    !#######################################################
-   pure subroutine calc_uslope_unstable(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_unstable(q,dq,i,j,k,n,ngrid)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       !--------------------------------------------
       ! Calculate unstable slope for each direction
       !--------------------------------------------
@@ -290,22 +290,22 @@ contains
 
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
          ! slopes in first coordinate direction
-         dlft = qcen - q(l,i-1,j,k)
-         drgt = q(l,i+1,j,k) - qcen
-         dq(l,1) = 0.5d0*(dlft+drgt)
+         dlft = qcen - q(l,i-1,j,k,n)
+         drgt = q(l,i+1,j,k,n) - qcen
+         dq(l,i,j,k,n,1) = 0.5d0*(dlft+drgt)
       end do
 
    end subroutine calc_uslope_unstable
 #endif
    !#######################################################
-   pure subroutine calc_uslope_vanLeer(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_vanLeer(q,dq,i,j,k,n,ngrid)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       !--------------------------------------------
       ! Calculate van Leer slope for each direction
       !--------------------------------------------
@@ -314,34 +314,34 @@ contains
 
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
 
          ! slopes in first coordinate direction
-         dlft = qcen - q(l,i-1,j,k)
-         drgt = q(l,i+1,j,k) - qcen
-         dq(l,1) = slope_vanLeer(dlft,drgt)
+         dlft = qcen - q(l,i-1,j,k,n)
+         drgt = q(l,i+1,j,k,n) - qcen
+         dq(l,i,j,k,n,1) = slope_vanLeer(dlft,drgt)
 #if NDIM>1
          ! slopes in second coordinate direction
-         dlft = qcen - q(l,i,j-1,k)
-         drgt = q(l,i,j+1,k) - qcen
-         dq(l,2) = slope_vanLeer(dlft,drgt)
+         dlft = qcen - q(l,i,j-1,k,n)
+         drgt = q(l,i,j+1,k,n) - qcen
+         dq(l,i,j,k,n,2) = slope_vanLeer(dlft,drgt)
 #endif
 #if NDIM>2
          ! slopes in third coordinate direction
-         dlft = qcen - q(l,i,j,k-1)
-         drgt = q(l,i,j,k+1) - qcen
-         dq(l,3) = slope_vanLeer(dlft,drgt)
+         dlft = qcen - q(l,i,j,k-1,n)
+         drgt = q(l,i,j,k+1,n) - qcen
+         dq(l,i,j,k,n,3) = slope_vanLeer(dlft,drgt)
 #endif
       end do
 
    end subroutine calc_uslope_vanLeer
    !#######################################################
-   pure subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,ngrid)
+   pure subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,n,ngrid)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       !--------------------------------------------------
       ! Calculate van Leer (bis) slope for each direction
       !--------------------------------------------------
@@ -350,23 +350,23 @@ contains
 
       do l = 1, ngrid
          ! Gather values at center cell and its neighbors
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
 
          ! slopes in first coordinate direction
-         dlft = qcen - q(l,i-1,j,k)
-         drgt = q(l,i+1,j,k) - qcen
-         dq(l,1) = slope_vanLeer_bis(dlft,drgt)
+         dlft = qcen - q(l,i-1,j,k,n)
+         drgt = q(l,i+1,j,k,n) - qcen
+         dq(l,i,j,k,n,1) = slope_vanLeer_bis(dlft,drgt)
 #if NDIM>1
          ! slopes in second coordinate direction
-         dlft = qcen - q(l,i,j-1,k)
-         drgt = q(l,i,j+1,k) - qcen
-         dq(l,2) = slope_vanLeer_bis(dlft,drgt)
+         dlft = qcen - q(l,i,j-1,k,n)
+         drgt = q(l,i,j+1,k,n) - qcen
+         dq(l,i,j,k,n,2) = slope_vanLeer_bis(dlft,drgt)
 #endif
 #if NDIM>2
          ! slopes in third coordinate direction
-         dlft = qcen - q(l,i,j,k-1)
-         drgt = q(l,i,j,k+1) - qcen
-         dq(l,3) = slope_vanLeer_bis(dlft,drgt)
+         dlft = qcen - q(l,i,j,k-1,n)
+         drgt = q(l,i,j,k+1,n) - qcen
+         dq(l,i,j,k,n,3) = slope_vanLeer_bis(dlft,drgt)
 #endif
       end do
 

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -9,6 +9,7 @@ contains
    !!! USLOPE SUBROUTINE FOR EACH SLOPE TYPE !!!
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+   !DIR$ ATTRIBUTES FORCEINLINE :: calc_uslope_minmod_average
    pure subroutine calc_uslope_minmod_average(q,dq,i,j,k,ngrid,slope_type_real)
       use hydro_parameters
       implicit none

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -1,5 +1,6 @@
 module slope_types
    use amr_parameters, only:dp,nvector,ndim
+   use hydro_parameters, only:nvar,iu1,iu2,ju1,ju2,ku1,ku2
    use const
    implicit none
 
@@ -10,13 +11,12 @@ contains
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !DIR$ FORCEINLINE :: calc_uslope_minmod_average
-   pure subroutine calc_uslope_minmod_average(q,dq,i,j,k,ngrid,slope_type_real)
-      use hydro_parameters
+   pure subroutine calc_uslope_minmod_average(q,dq,i,j,k,n,ngrid,slope_type_real)
       implicit none
-      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
-      real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+      real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
       integer,intent(in)::ngrid
-      integer,intent(in)::i, j, k
+      integer,intent(in)::i, j, k, n
       real(dp),intent(in)::slope_type_real
       !-----------------------------------------------------
       ! Calculate minmod or average slope for each direction
@@ -25,31 +25,31 @@ contains
       real(dp)::dlft, drgt, qcen
 
       do l = 1, ngrid
-         qcen = q(l,i,j,k)
+         qcen = q(l,i,j,k,n)
 
          ! slopes in first coordinate direction
-         dlft = qcen - q(l,i-1,j,k)
-         drgt = q(l,i+1,j,k) - qcen
+         dlft = qcen - q(l,i-1,j,k,n)
+         drgt = q(l,i+1,j,k,n) - qcen
 #if NDIM==1 || NDIM==2
-         dq(l,1) = slope_minmod_or_average(dlft,drgt,slope_type_real)
+         dq(l,i,j,k,n,1) = slope_minmod_or_average(dlft,drgt,slope_type_real)
 #else
-         dq(l,1) = slope_minmod(dlft,drgt)
+         dq(l,i,j,k,n,1) = slope_minmod(dlft,drgt)
 #endif
 #if NDIM>1
          ! slopes in second coordinate direction
-         dlft = qcen - q(l,i,j-1,k)
-         drgt = q(l,i,j+1,k) - qcen
+         dlft = qcen - q(l,i,j-1,k,n)
+         drgt = q(l,i,j+1,k,n) - qcen
 #if NDIM==2
-         dq(l,2) = slope_minmod_or_average(dlft,drgt,slope_type_real)
+         dq(l,i,j,k,n,2) = slope_minmod_or_average(dlft,drgt,slope_type_real)
 #else
-         dq(l,2) = slope_minmod(dlft,drgt)
+         dq(l,i,j,k,n,2) = slope_minmod(dlft,drgt)
 #endif
 #endif
 #if NDIM>2
          ! slopes in third coordinate direction
-         dlft = qcen - q(l,i,j,k-1)
-         drgt = q(l,i,j,k+1) - qcen
-         dq(l,3) = slope_minmod(dlft,drgt)
+         dlft = qcen - q(l,i,j,k-1,n)
+         drgt = q(l,i,j,k+1,n) - qcen
+         dq(l,i,j,k,n,3) = slope_minmod(dlft,drgt)
 #endif
       end do
 
@@ -57,7 +57,6 @@ contains
    !#######################################################
 #if NDIM==3
    pure subroutine calc_uslope_moncen(q,dq,i,j,k,ngrid)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -94,7 +93,6 @@ contains
    !#######################################################
 #if NDIM==2
    pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -142,7 +140,6 @@ contains
    end subroutine calc_uslope_positivity_preserving
 #elif NDIM==3
    pure subroutine calc_uslope_positivity_preserving(q,dq,i,j,k,ngrid)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -219,7 +216,6 @@ contains
    !#######################################################
 #if NDIM==1
    pure subroutine calc_uslope_superbee(q,dq,i,j,k,n,ngrid,dtdx)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -249,7 +245,6 @@ contains
    end subroutine calc_uslope_superbee
    !#######################################################
    pure subroutine calc_uslope_ultrabee(q,dq,i,j,k,n,ngrid,dtdx)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -283,7 +278,6 @@ contains
    end subroutine calc_uslope_ultrabee
    !#######################################################
    pure subroutine calc_uslope_unstable(q,dq,i,j,k,ngrid)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -308,7 +302,6 @@ contains
 #endif
    !#######################################################
    pure subroutine calc_uslope_vanLeer(q,dq,i,j,k,ngrid)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq
@@ -345,7 +338,6 @@ contains
    end subroutine calc_uslope_vanLeer
    !#######################################################
    pure subroutine calc_uslope_vanLeer_bis(q,dq,i,j,k,ngrid)
-      use hydro_parameters
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2),intent(in)::q
       real(dp),dimension(1:nvector,1:ndim),intent(out)::dq

--- a/hydro/slope_types.f90
+++ b/hydro/slope_types.f90
@@ -58,7 +58,7 @@ contains
 
    end subroutine calc_uslope_minmod_average
    !#######################################################
-#if NDIM==3 || defined(SOLVERhydro)
+#if NDIM==3 && defined(SOLVERhydro)
    pure subroutine calc_uslope_moncen(q,dq,i,j,k,n,ngrid)
       implicit none
       real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q

--- a/hydro/umuscl.f90
+++ b/hydro/umuscl.f90
@@ -919,8 +919,8 @@ end subroutine ctoprim
 !###########################################################
 !###########################################################
 subroutine uslope(q,dq,dx,dt,ngrid)
-  use amr_parameters, only:dp,nvector,ndim,iu1,iu2,ju1,ju2,ku1,ku2
-  use hydro_parameters, only:nvar,slope_type
+  use amr_parameters, only:dp,nvector,ndim
+  use hydro_parameters, only:nvar,slope_type,iu1,iu2,ju1,ju2,ku1,ku2
   use const
   use slope_types
   implicit none
@@ -955,7 +955,7 @@ subroutine uslope(q,dq,dx,dt,ngrid)
 #else
               else if(slope_type==1)then ! minmod
 #endif
-                 call calc_uslope_minmod_average(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid,slope_type_real)
+                 call calc_uslope_minmod_average(q,dq,i,j,k,n,ngrid,slope_type_real)
 #if NDIM==3
               else if(slope_type==2)then
                  ! moncen

--- a/hydro/umuscl.f90
+++ b/hydro/umuscl.f90
@@ -919,21 +919,20 @@ end subroutine ctoprim
 !###########################################################
 !###########################################################
 subroutine uslope(q,dq,dx,dt,ngrid)
-  use amr_parameters
-  use hydro_parameters
+  use amr_parameters, only:dp,nvector,ndim,iu1,iu2,ju1,ju2,ku1,ku2
+  use hydro_parameters, only:nvar,slope_type
   use const
   use slope_types
   implicit none
 
-  integer::ngrid
-  real(dp)::dx,dt,dtdx
-  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar)::q
-  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim)::dq
+  integer,intent(in)::ngrid
+  real(dp),intent(in)::dx,dt
+  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
 
   ! local arrays
   integer::i, j, k, l, n
-  real(dp)::dsgn, dlim, dcen, dlft, drgt, qcen
-  real(dp)::slope_type_real
+  real(dp)::slope_type_real,dtdx
   integer::ilo,ihi,jlo,jhi,klo,khi
 
   ilo=MIN(1,iu1+1); ihi=MAX(1,iu2-1)
@@ -948,44 +947,52 @@ subroutine uslope(q,dq,dx,dt,ngrid)
         do j = jlo, jhi
            do i = ilo, ihi
               if(slope_type==0)then
-                 dq=zero
+                 dq(:,i,j,k,n,:) = zero
 #if NDIM==1
               else if(slope_type==1.or.slope_type==2.or.slope_type==3)then  ! minmod or average
 #elif NDIM==2
               else if(slope_type==1.or.slope_type==2)then  ! minmod or average
 #else
-              else if(slope_type==1)then  ! minmod
+              else if(slope_type==1)then ! minmod
 #endif
                  call calc_uslope_minmod_average(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid,slope_type_real)
 #if NDIM==3
-              else if(slope_type==2)then ! moncen
+              else if(slope_type==2)then
+                 ! moncen
                  call calc_uslope_moncen(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 #endif
 #if NDIM>1
-              else if(slope_type==3)then ! positivity preserving unsplit slope
+              else if(slope_type==3)then 
+                 ! positivity preserving unsplit slope (2D or 3D)
                  call calc_uslope_positivity_preserving(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 #endif
 #if NDIM==1
-              else if(slope_type==4)then ! superbee
+              else if(slope_type==4)then
+                 ! superbee (only 1D)
                  call calc_uslope_superbee(q,dq(:,i,j,k,n,:),i,j,k,n,ngrid,dtdx)
 
-              else if(slope_type==5)then ! ultrabee
+              else if(slope_type==5)then
+                 ! ultrabee (only 1D)
                  if(n==1)then
                     call calc_uslope_ultrabee(q,dq(:,i,j,k,n,:),i,j,k,n,ngrid,dtdx)
                  else
-                    dq(:,i,j,k,n,:) = 0
+                    dq(:,i,j,k,n,:) = zero
                  endif
 
-              else if(slope_type==6)then ! unstable
+              else if(slope_type==6)then
+                 ! unstable (only 1D)
                  if(n==1)then
                     call calc_uslope_unstable(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
                  else
-                    dq(:,i,j,k,n,:) = 0
+                    dq(:,i,j,k,n,:) = zero
                  endif
 #endif
-              else if(slope_type==7)then ! van Leer
-                 call calc_uslope_vanLeer_bis(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
-              else if(slope_type==8)then ! generalized moncen/minmod parameterisation (van Leer 1979)
+              else if(slope_type==7)then
+                 ! van Leer
+                 call calc_uslope_vanLeer(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
+
+              else if(slope_type==8)then
+                 ! generalized moncen/minmod parameterisation (van Leer 1979)
                  call calc_uslope_vanLeer_bis(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 
               else

--- a/hydro/umuscl.f90
+++ b/hydro/umuscl.f90
@@ -926,7 +926,7 @@ subroutine uslope(q,dq,dx,dt,ngrid)
   implicit none
 
   integer::ngrid
-  real(dp)::dx,dt
+  real(dp)::dx,dt,dtdx
   real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar)::q
   real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim)::dq
 
@@ -934,18 +934,6 @@ subroutine uslope(q,dq,dx,dt,ngrid)
   integer::i, j, k, l, n
   real(dp)::dsgn, dlim, dcen, dlft, drgt, qcen
   real(dp)::slope_type_real
-#if NDIM==2
-  real(dp)::dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr
-#endif
-#if NDIM==3
-  real(dp)::dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl
-  real(dp)::dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm
-  real(dp)::dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr
-  real(dp)::dfz
-#endif
-#if NDIM>1
-  real(dp)::vmin,vmax,dfx,dfy,dff
-#endif
   integer::ilo,ihi,jlo,jhi,klo,khi
 
   ilo=MIN(1,iu1+1); ihi=MAX(1,iu2-1)
@@ -953,6 +941,7 @@ subroutine uslope(q,dq,dx,dt,ngrid)
   klo=MIN(1,ku1+1); khi=MAX(1,ku2-1)
 
   slope_type_real = REAL(slope_type, kind=dp)
+  dtdx=dt/dx
 
   do n = 1, nvar
      do k = klo, khi
@@ -970,208 +959,32 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                  call calc_uslope_minmod_average(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid,slope_type_real)
 #if NDIM==3
               else if(slope_type==2)then ! moncen
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dq(l,i,j,k,n,1) = slope_moncen(dlft,drgt)
-
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-                    dq(l,i,j,k,n,2) = slope_moncen(dlft,drgt)
-
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_moncen(dlft,drgt)
-                 end do
+                 call calc_uslope_moncen(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 #endif
-#if NDIM==2
-              else if(slope_type==3)then ! positivity preserving 2d unsplit slope
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    dfll = q(l,i-1,j-1,k,n) - qcen
-                    dflm = q(l,i-1,j  ,k,n) - qcen
-                    dflr = q(l,i-1,j+1,k,n) - qcen
-                    dfml = q(l,i  ,j-1,k,n) - qcen
-                    dfmm = 0
-                    dfmr = q(l,i  ,j+1,k,n) - qcen
-                    dfrl = q(l,i+1,j-1,k,n) - qcen
-                    dfrm = q(l,i+1,j  ,k,n) - qcen
-                    dfrr = q(l,i+1,j+1,k,n) - qcen
-
-                    vmin = min(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
-                    vmax = max(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
-
-                    dfx  = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
-                    dfy  = half*(q(l,i,j+1,k,n)-q(l,i,j-1,k,n))
-                    dff  = half*(abs(dfx)+abs(dfy))
-
-                    if(dff>zero)then
-                       dlim = min(one,min(abs(vmin),abs(vmax))/dff)
-                    else
-                       dlim = one
-                    endif
-
-                    dq(l,i,j,k,n,1) = dlim*dfx
-                    dq(l,i,j,k,n,2) = dlim*dfy
-                 end do
-#endif
-#if NDIM==3
-              else if(slope_type==3)then ! positivity preserving 3d unsplit slope
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    qcen = q(l,i,j,k,n)
-
-                    dflll = q(l,i-1,j-1,k-1,n) - qcen
-                    dflml = q(l,i-1,j  ,k-1,n) - qcen
-                    dflrl = q(l,i-1,j+1,k-1,n) - qcen
-                    dfmll = q(l,i  ,j-1,k-1,n) - qcen
-                    dfmml = q(l,i  ,j  ,k-1,n) - qcen
-                    dfmrl = q(l,i  ,j+1,k-1,n) - qcen
-                    dfrll = q(l,i+1,j-1,k-1,n) - qcen
-                    dfrml = q(l,i+1,j  ,k-1,n) - qcen
-                    dfrrl = q(l,i+1,j+1,k-1,n) - qcen
-
-                    dfllm = q(l,i-1,j-1,k  ,n) - qcen
-                    dflmm = q(l,i-1,j  ,k  ,n) - qcen
-                    dflrm = q(l,i-1,j+1,k  ,n) - qcen
-                    dfmlm = q(l,i  ,j-1,k  ,n) - qcen
-                    dfmmm = 0
-                    dfmrm = q(l,i  ,j+1,k  ,n) - qcen
-                    dfrlm = q(l,i+1,j-1,k  ,n) - qcen
-                    dfrmm = q(l,i+1,j  ,k  ,n) - qcen
-                    dfrrm = q(l,i+1,j+1,k  ,n) - qcen
-
-                    dfllr = q(l,i-1,j-1,k+1,n) - qcen
-                    dflmr = q(l,i-1,j  ,k+1,n) - qcen
-                    dflrr = q(l,i-1,j+1,k+1,n) - qcen
-                    dfmlr = q(l,i  ,j-1,k+1,n) - qcen
-                    dfmmr = q(l,i  ,j  ,k+1,n) - qcen
-                    dfmrr = q(l,i  ,j+1,k+1,n) - qcen
-                    dfrlr = q(l,i+1,j-1,k+1,n) - qcen
-                    dfrmr = q(l,i+1,j  ,k+1,n) - qcen
-                    dfrrr = q(l,i+1,j+1,k+1,n) - qcen
-
-                    vmin = min(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
-                         &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
-                         &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
-                    vmax = max(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
-                         &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
-                         &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
-
-                    dfx  = half*(q(l,i+1,j,k,n) - q(l,i-1,j,k,n))
-                    dfy  = half*(q(l,i,j+1,k,n) - q(l,i,j-1,k,n))
-                    dfz  = half*(q(l,i,j,k+1,n) - q(l,i,j,k-1,n))
-                    dff  = half*(abs(dfx)+abs(dfy)+abs(dfz))
-
-                    if(dff>zero)then
-                       dlim = min(one,min(abs(vmin),abs(vmax))/dff)
-                    else
-                       dlim = one
-                    endif
-
-                    dq(l,i,j,k,n,1) = dlim*dfx
-                    dq(l,i,j,k,n,2) = dlim*dfy
-                    dq(l,i,j,k,n,3) = dlim*dfz
-                 end do
+#if NDIM>1
+              else if(slope_type==3)then ! positivity preserving unsplit slope
+                 call calc_uslope_positivity_preserving(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 #endif
 #if NDIM==1
               else if(slope_type==4)then ! superbee
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-                    dcen = q(l,i,j,k,2)*dt/dx
-                    ! slopes in first coordinate direction
-                    dlft = two/(one+dcen)*(qcen - q(l,i-1,j,k,n))
-                    drgt = two/(one-dcen)*(q(l,i+1,j,k,n) - qcen)
-                    !dcen = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
-                    dsgn = sign(one, dlft)
-                    dlim = min(abs(dlft),abs(drgt))
-                    if((dlft*drgt)<=zero)dlim=zero
-                    dq(l,i,j,k,n,1) = dsgn*dlim !min(dlim,abs(dcen))
-                 end do
+                 call calc_uslope_superbee(q,dq(:,i,j,k,n,:),i,j,k,n,ngrid,dtdx)
 
               else if(slope_type==5)then ! ultrabee
                  if(n==1)then
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-                    dcen = q(l,i,j,k,2)*dt/dx
-                    if(dcen>=0)then
-                       dlft = two/(zero+dcen+1d-10)*(qcen - q(l,i-1,j,k,n))
-                       drgt = two/(one -dcen      )*(q(l,i+1,j,k,n) - qcen)
-                    else
-                       dlft = two/(one +dcen      )*(qcen - q(l,i-1,j,k,n))
-                       drgt = two/(zero-dcen+1d-10)*(q(l,i+1,j,k,n) - qcen)
-                    endif
-                    dsgn = sign(one, dlft)
-                    dlim = min(abs(dlft),abs(drgt))
-                    !dcen = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
-                    if((dlft*drgt)<=zero)dlim=zero
-                    dq(l,i,j,k,n,1) = dsgn*dlim !min(dlim,abs(dcen))
-                 end do
+                    call calc_uslope_ultrabee(q,dq(:,i,j,k,n,:),i,j,k,n,ngrid,dtdx)
                  else
-                 dq(:,i,j,k,n,:) = 0
+                    dq(:,i,j,k,n,:) = 0
                  endif
 
               else if(slope_type==6)then ! unstable
                  if(n==1)then
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dlim = 0.5d0*(dlft+drgt)
-                    dq(l,i,j,k,n,1) = dlim
-                 end do
+                    call calc_uslope_unstable(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
                  else
-                 dq(:,i,j,k,n,:) = 0
+                    dq(:,i,j,k,n,:) = 0
                  endif
 #endif
               else if(slope_type==7)then ! van Leer
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dq(l,i,j,k,n,1) = slope_vanLeer(dlft,drgt)
-#if NDIM>1
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-                    dq(l,i,j,k,n,2) = slope_vanLeer(dlft,drgt)
-#endif
-#if NDIM>2
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_vanLeer(dlft,drgt)
-#endif
-                 end do
-
+                 call calc_uslope_vanLeer_bis(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
               else if(slope_type==8)then ! generalized moncen/minmod parameterisation (van Leer 1979)
                  call calc_uslope_vanLeer_bis(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 

--- a/hydro/umuscl.f90
+++ b/hydro/umuscl.f90
@@ -952,20 +952,23 @@ subroutine uslope(q,dq,dx,dt,ngrid)
   jlo=MIN(1,ju1+1); jhi=MAX(1,ju2-1)
   klo=MIN(1,ku1+1); khi=MAX(1,ku2-1)
 
-  if(slope_type==0)then
-     dq=zero
+  slope_type_real = REAL(slope_type, kind=dp)
+
+  do n = 1, nvar
+     do k = klo, khi
+        do j = jlo, jhi
+           do i = ilo, ihi
+              if(slope_type==0)then
+                 dq=zero
 #if NDIM==1
-  else if(slope_type==1.or.slope_type==2.or.slope_type==3)then  ! minmod or average
+              else if(slope_type==1.or.slope_type==2.or.slope_type==3)then  ! minmod or average
 #elif NDIM==2
-  else if(slope_type==1.or.slope_type==2)then  ! minmod or average
+              else if(slope_type==1.or.slope_type==2)then  ! minmod or average
 #else
-  else if(slope_type==1)then  ! minmod
+              else if(slope_type==1)then  ! minmod
 #endif
-     slope_type_real = REAL(slope_type, kind=dp)
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     qcen = q(l,i,j,k,n)
 
@@ -994,16 +997,10 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     dq(l,i,j,k,n,3) = slope_minmod(dlft,drgt)
 #endif
                  end do
-              end do
-           end do
-        end do
-     end do
 #if NDIM==3
-  else if(slope_type==2)then ! moncen
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+              else if(slope_type==2)then ! moncen
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1023,17 +1020,11 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     drgt = q(l,i,j,k+1,n) - qcen
                     dq(l,i,j,k,n,3) = slope_moncen(dlft,drgt)
                  end do
-              end do
-           end do
-        end do
-     end do
 #endif
 #if NDIM==2
-  else if(slope_type==3)then ! positivity preserving 2d unsplit slope
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+              else if(slope_type==3)then ! positivity preserving 2d unsplit slope
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1064,17 +1055,11 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     dq(l,i,j,k,n,1) = dlim*dfx
                     dq(l,i,j,k,n,2) = dlim*dfy
                  end do
-              end do
-           end do
-        end do
-     end do
 #endif
 #if NDIM==3
-  else if(slope_type==3)then ! positivity preserving 3d unsplit slope
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+              else if(slope_type==3)then ! positivity preserving 3d unsplit slope
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     qcen = q(l,i,j,k,n)
 
@@ -1130,17 +1115,11 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     dq(l,i,j,k,n,2) = dlim*dfy
                     dq(l,i,j,k,n,3) = dlim*dfz
                  end do
-              end do
-           end do
-        end do
-     end do
 #endif
 #if NDIM==1
-  else if(slope_type==4)then ! superbee
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+              else if(slope_type==4)then ! superbee
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1154,16 +1133,11 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     if((dlft*drgt)<=zero)dlim=zero
                     dq(l,i,j,k,n,1) = dsgn*dlim !min(dlim,abs(dcen))
                  end do
-              end do
-           end do
-        end do
-     end do
-  else if(slope_type==5)then ! ultrabee
-        dq = 0
-        n=1
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+
+              else if(slope_type==5)then ! ultrabee
+                 if(n==1)then
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1181,15 +1155,14 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     if((dlft*drgt)<=zero)dlim=zero
                     dq(l,i,j,k,n,1) = dsgn*dlim !min(dlim,abs(dcen))
                  end do
-              end do
-           end do
-        end do
-  else if(slope_type==6)then ! unstable
-        dq = 0
-        n=1
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+                 else
+                 dq(:,i,j,k,n,:) = 0
+                 endif
+
+              else if(slope_type==6)then ! unstable
+                 if(n==1)then
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1199,15 +1172,13 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     dlim = 0.5d0*(dlft+drgt)
                     dq(l,i,j,k,n,1) = dlim
                  end do
-              end do
-           end do
-        end do
+                 else
+                 dq(:,i,j,k,n,:) = 0
+                 endif
 #endif
-  else if(slope_type==7)then ! van Leer
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+              else if(slope_type==7)then ! van Leer
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1229,15 +1200,10 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     dq(l,i,j,k,n,3) = slope_vanLeer(dlft,drgt)
 #endif
                  end do
-              end do
-           end do
-        end do
-     end do
-  else if(slope_type==8)then ! generalized moncen/minmod parameterisation (van Leer 1979)
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
+
+              else if(slope_type==8)then ! generalized moncen/minmod parameterisation (van Leer 1979)
+                 !DIR$ IVDEP
+                 !DIR$ SIMD
                  do l = 1, ngrid
                     ! Gather values at center cell and its neighbors
                     qcen = q(l,i,j,k,n)
@@ -1259,13 +1225,16 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                     dq(l,i,j,k,n,3) = slope_vanLeer_bis(dlft,drgt)
 #endif
                  end do
-              end do
+
+              else
+                 write(*,*)'Unknown slope type',dx,dt
+                 call clean_stop
+              endif
+
            end do
         end do
      end do
-  else
-     write(*,*)'Unknown slope type',dx,dt
-     call clean_stop
-  endif
+  end do
+
 
 end subroutine uslope

--- a/hydro/umuscl.f90
+++ b/hydro/umuscl.f90
@@ -959,22 +959,22 @@ subroutine uslope(q,dq,dx,dt,ngrid)
 #if NDIM==3
               else if(slope_type==2)then
                  ! moncen
-                 call calc_uslope_moncen(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
+                 call calc_uslope_moncen(q,dq,i,j,k,n,ngrid)
 #endif
 #if NDIM>1
               else if(slope_type==3)then 
                  ! positivity preserving unsplit slope (2D or 3D)
-                 call calc_uslope_positivity_preserving(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
+                 call calc_uslope_positivity_preserving(q,dq,i,j,k,n,ngrid)
 #endif
 #if NDIM==1
               else if(slope_type==4)then
                  ! superbee (only 1D)
-                 call calc_uslope_superbee(q,dq(:,i,j,k,n,:),i,j,k,n,ngrid,dtdx)
+                 call calc_uslope_superbee(q,dq,i,j,k,n,ngrid,dtdx)
 
               else if(slope_type==5)then
                  ! ultrabee (only 1D)
                  if(n==1)then
-                    call calc_uslope_ultrabee(q,dq(:,i,j,k,n,:),i,j,k,n,ngrid,dtdx)
+                    call calc_uslope_ultrabee(q,dq,i,j,k,n,ngrid,dtdx)
                  else
                     dq(:,i,j,k,n,:) = zero
                  endif
@@ -982,18 +982,18 @@ subroutine uslope(q,dq,dx,dt,ngrid)
               else if(slope_type==6)then
                  ! unstable (only 1D)
                  if(n==1)then
-                    call calc_uslope_unstable(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
+                    call calc_uslope_unstable(q,dq,i,j,k,n,ngrid)
                  else
                     dq(:,i,j,k,n,:) = zero
                  endif
 #endif
               else if(slope_type==7)then
                  ! van Leer
-                 call calc_uslope_vanLeer(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
+                 call calc_uslope_vanLeer(q,dq,i,j,k,n,ngrid)
 
               else if(slope_type==8)then
                  ! generalized moncen/minmod parameterisation (van Leer 1979)
-                 call calc_uslope_vanLeer_bis(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
+                 call calc_uslope_vanLeer_bis(q,dq,i,j,k,n,ngrid)
 
               else
                  write(*,*)'Unknown slope type',dx,dt

--- a/hydro/umuscl.f90
+++ b/hydro/umuscl.f90
@@ -967,36 +967,7 @@ subroutine uslope(q,dq,dx,dt,ngrid)
 #else
               else if(slope_type==1)then  ! minmod
 #endif
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    qcen = q(l,i,j,k,n)
-
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-#if NDIM==1 || NDIM==2
-                    dq(l,i,j,k,n,1) = slope_minmod_or_average(dlft,drgt,slope_type_real)
-#else
-                    dq(l,i,j,k,n,1) = slope_minmod(dlft,drgt)
-#endif
-#if NDIM>1
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-#if NDIM==2
-                    dq(l,i,j,k,n,2) = slope_minmod_or_average(dlft,drgt,slope_type_real)
-#else
-                    dq(l,i,j,k,n,2) = slope_minmod(dlft,drgt)
-#endif
-#endif
-#if NDIM>2
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_minmod(dlft,drgt)
-#endif
-                 end do
+                 call calc_uslope_minmod_average(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid,slope_type_real)
 #if NDIM==3
               else if(slope_type==2)then ! moncen
                  !DIR$ IVDEP
@@ -1202,29 +1173,7 @@ subroutine uslope(q,dq,dx,dt,ngrid)
                  end do
 
               else if(slope_type==8)then ! generalized moncen/minmod parameterisation (van Leer 1979)
-                 !DIR$ IVDEP
-                 !DIR$ SIMD
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dq(l,i,j,k,n,1) = slope_vanLeer_bis(dlft,drgt)
-#if NDIM>1
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-                    dq(l,i,j,k,n,2) = slope_vanLeer_bis(dlft,drgt)
-#endif
-#if NDIM>2
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_vanLeer_bis(dlft,drgt)
-#endif
-                 end do
+                 call calc_uslope_vanLeer_bis(q(:,:,:,:,n),dq(:,i,j,k,n,:),i,j,k,ngrid)
 
               else
                  write(*,*)'Unknown slope type',dx,dt

--- a/mhd/umuscl.f90
+++ b/mhd/umuscl.f90
@@ -2139,244 +2139,63 @@ end subroutine ctoprim
 !###########################################################
 !###########################################################
 subroutine uslope(q,dq,bf,dbf,dx,dt,ngrid)
-  use amr_parameters
-  use hydro_parameters
+  use amr_parameters, only:dp,nvector,ndim
+  use hydro_parameters, only:nvar,slope_type,slope_mag_type,iu1,iu2,ju1,ju2,ku1,ku2
   use const
   use slope_types
   implicit none
 
-  integer::ngrid
-  real(dp)::dx,dt
-  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar)::q
-  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim)::dq
-  real(dp),dimension(1:nvector,iu1:iu2+1,ju1:ju2+1,ku1:ku2+1,1:3)::bf
-  real(dp),dimension(1:nvector,iu1:iu2+1,ju1:ju2+1,ku1:ku2+1,1:3,1:ndim)::dbf
+  integer,intent(in)::ngrid
+  real(dp),intent(in)::dx,dt
+  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar),intent(in)::q
+  real(dp),dimension(1:nvector,iu1:iu2,ju1:ju2,ku1:ku2,1:nvar,1:ndim),intent(out)::dq
+  real(dp),dimension(1:nvector,iu1:iu2+1,ju1:ju2+1,ku1:ku2+1,1:3),intent(in)::bf
+  real(dp),dimension(1:nvector,iu1:iu2+1,ju1:ju2+1,ku1:ku2+1,1:3,1:ndim),intent(out)::dbf
 
   ! local arrays
   integer::i, j, k, l, n
-  real(dp)::dsgn, dlim, dcen, dlft, drgt, qcen, bcen
-  real(dp)::vmin,vmax,dff
-  real(dp)::slope_type_real
+  real(dp):: dlft, drgt, bcen
+  real(dp)::slope_type_real,dtdx
   integer::ilo,ihi,jlo,jhi,klo,khi
-
-#if NDIM==1
-  real(dp)::dfx
-#endif
-
-#if NDIM==2
-  real(dp)::dfx,dfy
-  real(dp)::dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr
-#endif
-
-#if NDIM==3
-  real(dp)::dfx,dfy,dfz
-  real(dp)::dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl
-  real(dp)::dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm
-  real(dp)::dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr
-#endif
 
   ilo=MIN(1,iu1+1); ihi=MAX(1,iu2-1)
   jlo=MIN(1,ju1+1); jhi=MAX(1,ju2-1)
   klo=MIN(1,ku1+1); khi=MAX(1,ku2-1)
 
-  if(slope_type==0)then
-    dq=zero
-  else if(slope_type==1.or.slope_type==2)then  ! minmod or average
-    slope_type_real = REAL(slope_type, kind=dp)
-    do n = 1, nvar
-       do k = klo, khi
-          do j = jlo, jhi
-             do i = ilo, ihi
-                do l = 1, ngrid
-                    qcen = q(l,i,j,k,n)
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dq(l,i,j,k,n,1) = slope_minmod_or_average(dlft,drgt,slope_type_real)
+  slope_type_real = REAL(slope_type, kind=dp)
+  dtdx=dt/dx
+
+  do n = 1, nvar
+     do k = klo, khi
+        do j = jlo, jhi
+           do i = ilo, ihi
+              if(slope_type==0)then
+                 dq(:,i,j,k,n,:) = zero
+              else if(slope_type==1.or.slope_type==2)then  ! minmod or average
+                 call calc_uslope_minmod_average(q,dq,i,j,k,n,ngrid,slope_type_real)
 #if NDIM>1
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-                    dq(l,i,j,k,n,2) = slope_minmod_or_average(dlft,drgt,slope_type_real)
-#endif
-#if NDIM>2
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_minmod_or_average(dlft,drgt,slope_type_real)
-#endif
-                 end do
-              end do
-           end do
-        end do
-     end do
-#if NDIM==2
-  else if(slope_type==3)then ! positivity preserving 2d unsplit slope
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    dfll = q(l,i-1,j-1,k,n) - qcen
-                    dflm = q(l,i-1,j  ,k,n) - qcen
-                    dflr = q(l,i-1,j+1,k,n) - qcen
-                    dfml = q(l,i  ,j-1,k,n) - qcen
-                    dfmm = 0
-                    dfmr = q(l,i  ,j+1,k,n) - qcen
-                    dfrl = q(l,i+1,j-1,k,n) - qcen
-                    dfrm = q(l,i+1,j  ,k,n) - qcen
-                    dfrr = q(l,i+1,j+1,k,n) - qcen
-
-                    vmin = min(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
-                    vmax = max(dfll,dflm,dflr,dfml,dfmm,dfmr,dfrl,dfrm,dfrr)
-
-                    dfx  = half*(q(l,i+1,j,k,n)-q(l,i-1,j,k,n))
-                    dfy  = half*(q(l,i,j+1,k,n)-q(l,i,j-1,k,n))
-                    dff  = half*(abs(dfx)+abs(dfy))
-
-                    if(dff>zero)then
-                       dlim = min(one,min(abs(vmin),abs(vmax))/dff)
-                    else
-                       dlim = one
-                    endif
-
-                    dq(l,i,j,k,n,1) = dlim*dfx
-                    dq(l,i,j,k,n,2) = dlim*dfy
-                 end do
-              end do
-           end do
-        end do
-     end do
+              else if(slope_type==3)then 
+                 ! positivity preserving unsplit slope (2D or 3D)
+                 call calc_uslope_positivity_preserving(q,dq,i,j,k,n,ngrid)
 #endif
 #if NDIM==3
-  else if(slope_type==3)then ! positivity preserving 3d unsplit slope
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
-                 do l = 1, ngrid
-                    qcen = q(l,i,j,k,n)
+              else if(slope_type==7)then
+                 ! van Leer
+                 call calc_uslope_vanLeer(q,dq,i,j,k,n,ngrid)
 
-                    dflll = q(l,i-1,j-1,k-1,n) - qcen
-                    dflml = q(l,i-1,j  ,k-1,n) - qcen
-                    dflrl = q(l,i-1,j+1,k-1,n) - qcen
-                    dfmll = q(l,i  ,j-1,k-1,n) - qcen
-                    dfmml = q(l,i  ,j  ,k-1,n) - qcen
-                    dfmrl = q(l,i  ,j+1,k-1,n) - qcen
-                    dfrll = q(l,i+1,j-1,k-1,n) - qcen
-                    dfrml = q(l,i+1,j  ,k-1,n) - qcen
-                    dfrrl = q(l,i+1,j+1,k-1,n) - qcen
-
-                    dfllm = q(l,i-1,j-1,k  ,n) - qcen
-                    dflmm = q(l,i-1,j  ,k  ,n) - qcen
-                    dflrm = q(l,i-1,j+1,k  ,n) - qcen
-                    dfmlm = q(l,i  ,j-1,k  ,n) - qcen
-                    dfmmm = 0
-                    dfmrm = q(l,i  ,j+1,k  ,n) - qcen
-                    dfrlm = q(l,i+1,j-1,k  ,n) - qcen
-                    dfrmm = q(l,i+1,j  ,k  ,n) - qcen
-                    dfrrm = q(l,i+1,j+1,k  ,n) - qcen
-
-                    dfllr = q(l,i-1,j-1,k+1,n) - qcen
-                    dflmr = q(l,i-1,j  ,k+1,n) - qcen
-                    dflrr = q(l,i-1,j+1,k+1,n) - qcen
-                    dfmlr = q(l,i  ,j-1,k+1,n) - qcen
-                    dfmmr = q(l,i  ,j  ,k+1,n) - qcen
-                    dfmrr = q(l,i  ,j+1,k+1,n) - qcen
-                    dfrlr = q(l,i+1,j-1,k+1,n) - qcen
-                    dfrmr = q(l,i+1,j  ,k+1,n) - qcen
-                    dfrrr = q(l,i+1,j+1,k+1,n) - qcen
-
-                    vmin = min(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
-                         &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
-                         &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
-                    vmax = max(dflll,dflml,dflrl,dfmll,dfmml,dfmrl,dfrll,dfrml,dfrrl, &
-                         &     dfllm,dflmm,dflrm,dfmlm,dfmmm,dfmrm,dfrlm,dfrmm,dfrrm, &
-                         &     dfllr,dflmr,dflrr,dfmlr,dfmmr,dfmrr,dfrlr,dfrmr,dfrrr)
-
-                    dfx  = half*(q(l,i+1,j,k,n) - q(l,i-1,j,k,n))
-                    dfy  = half*(q(l,i,j+1,k,n) - q(l,i,j-1,k,n))
-                    dfz  = half*(q(l,i,j,k+1,n) - q(l,i,j,k-1,n))
-                    dff  = half*(abs(dfx)+abs(dfy)+abs(dfz))
-
-                    if(dff>zero)then
-                       dlim = min(one,min(abs(vmin),abs(vmax))/dff)
-                    else
-                       dlim = one
-                    endif
-
-                    dq(l,i,j,k,n,1) = dlim*dfx
-                    dq(l,i,j,k,n,2) = dlim*dfy
-                    dq(l,i,j,k,n,3) = dlim*dfz
-                 end do
-              end do
-           end do
-        end do
-     end do
-  else if(slope_type==7)then ! van Leer
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dq(l,i,j,k,n,1) = slope_vanLeer(dlft,drgt)
-
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-                    dq(l,i,j,k,n,2) = slope_vanLeer(dlft,drgt)
-
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_vanLeer(dlft,drgt)
-                 end do
-              end do
-           end do
-        end do
-     end do
-  else if(slope_type==8)then ! generalized moncen/minmod parameterisation (van Leer 1979)
-     do n = 1, nvar
-        do k = klo, khi
-           do j = jlo, jhi
-              do i = ilo, ihi
-                 do l = 1, ngrid
-                    ! Gather values at center cell and its neighbors
-                    qcen = q(l,i,j,k,n)
-
-                    ! slopes in first coordinate direction
-                    dlft = qcen - q(l,i-1,j,k,n)
-                    drgt = q(l,i+1,j,k,n) - qcen
-                    dq(l,i,j,k,n,1) = slope_vanLeer_bis(dlft,drgt)
-
-                    ! slopes in second coordinate direction
-                    dlft = qcen - q(l,i,j-1,k,n)
-                    drgt = q(l,i,j+1,k,n) - qcen
-                    dq(l,i,j,k,n,2) = slope_vanLeer_bis(dlft,drgt)
-
-                    ! slopes in third coordinate direction
-                    dlft = qcen - q(l,i,j,k-1,n)
-                    drgt = q(l,i,j,k+1,n) - qcen
-                    dq(l,i,j,k,n,3) = slope_vanLeer_bis(dlft,drgt)
-                 end do
-              end do
-           end do
-        end do
-     end do
+              else if(slope_type==8)then
+                 ! generalized moncen/minmod parameterisation (van Leer 1979)
+                 call calc_uslope_vanLeer_bis(q,dq,i,j,k,n,ngrid)
 #endif
-  else
-     write(*,*)'Unknown slope type',dx,dt
-     call clean_stop
-  endif
+              else
+                 write(*,*)'Unknown slope type',dx,dt
+                 call clean_stop
+              endif
+           end do
+        end do
+     end do
+  end do
+
 
   ! 1D/2D transverse TVD slopes for face-centered magnetic fields
 #if NDIM>1


### PR DESCRIPTION
I've moved the if-check inwards, so that the outer loop i,j,k is now only done once. Then I created vectorized subroutines for each  slope_type, so that uslope is now effectively a wrapper routine to select the requested slope type.
By keeping the dimensions of input and output arrays the same as before, the compiler properly inlines and vectorizes. And so the execution time is unaffected.

This structure will allow to move the call to uslope inside trace, bypassing a slow store-load operation. This change will be made in a separate PR.